### PR TITLE
Update to fix issue custom port specifications

### DIFF
--- a/varnish-graphite
+++ b/varnish-graphite
@@ -34,7 +34,7 @@ class GraphiteClient:
         self.sock = None
         logging.warning("Connection failed. Re-trying on the next interval")
       try:
-        self.sock.connect((self.host, self.port))
+        self.sock.connect((self.host, int(self.port)))
       except socket.error:
         self.sock.close()
         self.sock = None


### PR DESCRIPTION
This change was needed to fix an issue I bumped into when specifying a port number:

./varnish-graphite -H 172.22.0.10 -p 2003
Traceback (most recent call last):
  File "./varnish-graphite", line 145, in <module>
    main()
  File "./varnish-graphite", line 132, in main
    c = GraphiteClient(args.host, args.port, args.prefix, args.buffer_size, args.max_buffer_size)
  File "./varnish-graphite", line 27, in **init**
    self.connect()
  File "./varnish-graphite", line 37, in connect
    self.sock.connect((self.host, self.port))
  File "/usr/lib/python2.7/socket.py", line 224, in meth
    return getattr(self._sock,name)(*args)
TypeError: an integer is required
